### PR TITLE
fix(config): include components that have no incoming edges

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -102,7 +102,8 @@ function sort(configs: Config[]): Config[] {
   const byName = Object.fromEntries(configs.map((c) => [c.name, c]));
   const byProducerOf = Object.fromEntries(configs.flatMap((c) => c.monorepo.produces.map((p) => [p, c])));
 
-  const sorted = toposort(
+  const sorted = toposort.array(
+    Object.keys(byName),
     configs.flatMap((c) => {
       return c.monorepo.expects.map((e) => {
         return byProducerOf[e]

--- a/test/cmd/pipeline.test.ts
+++ b/test/cmd/pipeline.test.ts
@@ -49,6 +49,7 @@ describe('monofo pipeline', () => {
           'echo "foo1" > foo1',
           "echo 'bar was replaced'",
           'echo "baz1"',
+          'echo "unreferenced" > unref',
         ]);
         const { plugins } = p.steps[0];
         expect(plugins ? plugins[0]['artifacts#v1.3.0'] : null).toStrictEqual({
@@ -60,7 +61,7 @@ describe('monofo pipeline', () => {
       });
   });
 
-  it('can be executed with simple configuration on the default branch', async () => {
+  it('can be executed with simple configuration and skipped parts on the default branch', async () => {
     process.env = fakeProcess();
     process.chdir(path.resolve(__dirname, '../projects/skipped'));
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -11,10 +11,11 @@ describe('getConfig()', () => {
     process.chdir(path.resolve(__dirname, 'projects/simple'));
     const config = await getConfigs();
 
-    expect(config).toHaveLength(4);
+    expect(config).toHaveLength(5);
     expect(config[0].name).toBe('foo');
     expect([config[1].name, config[2].name]).toContain('bar');
     expect([config[1].name, config[2].name]).toContain('qux');
     expect(config[3].name).toBe('baz');
+    expect(config[4].name).toBe('unreferenced');
   });
 });

--- a/test/projects/simple/.buildkite/pipeline.unreferenced.yml
+++ b/test/projects/simple/.buildkite/pipeline.unreferenced.yml
@@ -1,0 +1,6 @@
+monorepo:
+  matches:
+    - "**"
+
+steps:
+  - command: echo "unreferenced" > unref


### PR DESCRIPTION
toposort only returns nodes that are mentioned in the edges - toposort.array is what we want; it always returns the same number of nodes as it was given.