### PR TITLE
Don't depend on artifact step if it's not needed

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ env:
 steps:
   - label: ":docker:"
     agents:
-      queue: docker-build
+      queue: build
     plugins:
       - docker-compose#v3.3.0:
           build: [node, node-14]

--- a/test/cmd/pipeline.test.ts
+++ b/test/cmd/pipeline.test.ts
@@ -84,7 +84,7 @@ describe('monofo pipeline', () => {
       });
   });
 
-  it('can be executed with crossdeps', async () => {
+  it('can be executed with crossdeps alone', async () => {
     process.env = fakeProcess();
     process.chdir(path.resolve(__dirname, '../projects/crossdeps'));
 
@@ -93,19 +93,11 @@ describe('monofo pipeline', () => {
       .then((o) => (safeLoad(o) as unknown) as Pipeline)
       .then((p) => {
         expect(p).toBeDefined();
-        expect(p.steps).toHaveLength(2);
-        // TODO: update expectations once the artifacts step is here
-        // expect(p.steps.map((s) => s.command)).toStrictEqual([
-        //   "echo 'inject for: foo, bar'",
-        //   "echo 'bar was replaced'",
-        //   "echo 'All build parts were skipped'",
-        // ]);
-        // const { plugins } = p.steps[0];
-        // expect(plugins ? plugins[0]['artifacts#v1.3.0'] : null).toStrictEqual({
-        //   build: BUILD_ID,
-        //   download: ['foo1', 'bar1', 'bar2'],
-        //   upload: ['foo1', 'bar1', 'bar2'],
-        // });
+
+        // This had a cross-dependency, but the thing it depended on was skipped
+        // In addition, nothing that was skipped was producing required artifacts
+        // So the artifact step was skipped. This step can now run immediately.
+        expect(p.steps[0].depends_on).toHaveLength(0);
       });
   });
 });

--- a/test/cmd/pipeline.test.ts
+++ b/test/cmd/pipeline.test.ts
@@ -83,4 +83,29 @@ describe('monofo pipeline', () => {
         });
       });
   });
+
+  it('can be executed with crossdeps', async () => {
+    process.env = fakeProcess();
+    process.chdir(path.resolve(__dirname, '../projects/crossdeps'));
+
+    const args: Arguments<unknown> = { $0: '', _: [] };
+    await ((pipeline.handler(args) as unknown) as Promise<string>)
+      .then((o) => (safeLoad(o) as unknown) as Pipeline)
+      .then((p) => {
+        expect(p).toBeDefined();
+        expect(p.steps).toHaveLength(2);
+        // TODO: update expectations once the artifacts step is here
+        // expect(p.steps.map((s) => s.command)).toStrictEqual([
+        //   "echo 'inject for: foo, bar'",
+        //   "echo 'bar was replaced'",
+        //   "echo 'All build parts were skipped'",
+        // ]);
+        // const { plugins } = p.steps[0];
+        // expect(plugins ? plugins[0]['artifacts#v1.3.0'] : null).toStrictEqual({
+        //   build: BUILD_ID,
+        //   download: ['foo1', 'bar1', 'bar2'],
+        //   upload: ['foo1', 'bar1', 'bar2'],
+        // });
+      });
+  });
 });

--- a/test/projects/crossdeps/.buildkite/pipeline.baz.yml
+++ b/test/projects/crossdeps/.buildkite/pipeline.baz.yml
@@ -1,0 +1,7 @@
+monorepo:
+  matches:
+    - "baz/**/*.ts" # will match
+
+steps:
+  - command: 'echo "baz1" | tee baz1'
+    depends_on: fooKey1

--- a/test/projects/crossdeps/.buildkite/pipeline.foo.yml
+++ b/test/projects/crossdeps/.buildkite/pipeline.foo.yml
@@ -1,0 +1,6 @@
+monorepo:
+  matches: no-match
+
+steps:
+  - command: echo "foo1" > foo1
+    key: fooKey1


### PR DESCRIPTION
If we aren't replacing any actual artifacts in the build, we don't need to add an artifact step. And if we don't, we should replace _skipped depends_on keys_ with _nothing_ rather than _the replacement artifact-step key_ (current behavior).

Fixes a bug where we would leave the build hanging, waiting for an artifact step that was never added.