### PR TITLE
feat(steps): allow for phony dependencies

### DIFF
--- a/src/steps.ts
+++ b/src/steps.ts
@@ -7,7 +7,10 @@ const ARTIFACT_INJECTION_STEP_LABEL = `:crystal_ball:`;
 
 export function artifactInjectionSteps(configs: ConfigWithDecision[]): Step[] {
   const names = configs.filter((c) => !c.included).map((c) => c.name);
-  const produces = configs.filter((c) => !c.included).flatMap((e) => e.monorepo.produces);
+  const produces = configs
+    .filter((c) => !c.included)
+    .flatMap((e) => e.monorepo.produces)
+    .filter((artifact) => !artifact.startsWith('.phony/'));
   const { buildId } = configs[0];
 
   if (names.length < 1 || produces.length < 1 || !buildId) {

--- a/test/cmd/pipeline.test.ts
+++ b/test/cmd/pipeline.test.ts
@@ -93,6 +93,7 @@ describe('monofo pipeline', () => {
       .then((o) => (safeLoad(o) as unknown) as Pipeline)
       .then((p) => {
         expect(p).toBeDefined();
+        expect(p.steps).toHaveLength(1); // No artifacts step, because only phony artifacts involved
 
         // This had a cross-dependency, but the thing it depended on was skipped
         // In addition, nothing that was skipped was producing required artifacts

--- a/test/projects/crossdeps/.buildkite/pipeline.baz.yml
+++ b/test/projects/crossdeps/.buildkite/pipeline.baz.yml
@@ -1,4 +1,6 @@
 monorepo:
+  expects:
+    - .phony/foo
   matches:
     - "baz/**/*.ts" # will match
 

--- a/test/projects/crossdeps/.buildkite/pipeline.foo.yml
+++ b/test/projects/crossdeps/.buildkite/pipeline.foo.yml
@@ -1,4 +1,6 @@
 monorepo:
+  produces:
+    - .phony/foo
   matches: no-match
 
 steps:


### PR DESCRIPTION
Exclude artifacts starting with `.phony/` from the actual upload/download attempt made as part of monofo. They remain part of sorting the subpipelines. This means we can now arbitrarily order pipelines.

A better way would have been to add `before`/`after` properties to the config, but this is such a slim one-line change it's hard to resist. I can see why `make` follows this pattern.