### PR TITLE
feat(core): allow setting env values when excluded

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,7 @@ async function readConfig(config: ConfigFile): Promise<ConfigFile> {
         produces: strings(monorepo.produces),
         matches: strings(monorepo.matches),
         excluded_steps: monorepo.excluded_steps || [],
+        excluded_env: monorepo.excluded_env || {},
       },
       steps,
       env,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -78,7 +78,7 @@ function toMerge({ steps, env, included, monorepo }: ConfigWithDecision): Pipeli
         steps,
       }
     : {
-        env: {},
+        env: Object.entries(monorepo.excluded_env).length > 0 ? monorepo.excluded_env : {},
         steps: monorepo.excluded_steps.length > 0 ? monorepo.excluded_steps : [],
       };
 }

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -10,6 +10,7 @@ interface Config extends ConfigFile {
     produces: string[];
     matches: string[];
     excluded_steps: Record<string, unknown>[];
+    excluded_env: Record<string, string>;
   };
   steps: Step[];
   env: Record<string, string>;

--- a/test/cmd/pipeline.test.ts
+++ b/test/cmd/pipeline.test.ts
@@ -58,7 +58,8 @@ describe('monofo pipeline', () => {
           download: ['bar1', 'bar2', 'qux1'],
           upload: ['bar1', 'bar2', 'qux1'],
         });
-        expect(Object.entries(p.env)).toHaveLength(3); // merged from only included files
+        expect(Object.entries(p.env)).toHaveLength(4);
+        expect(p.env.BAR_WAS_EXCLUDED).toBe('true');
       });
   });
 

--- a/test/projects/simple/.buildkite/pipeline.bar.yml
+++ b/test/projects/simple/.buildkite/pipeline.bar.yml
@@ -8,6 +8,8 @@ monorepo:
   excluded_steps:
     - label: "Some other step"
       command: "echo 'bar was replaced'"
+  excluded_env:
+    BAR_WAS_EXCLUDED: "true"
 
 env:
   BAR: some-value


### PR DESCRIPTION
This allows e.g. setting NODE_IMAGE="node-${BUILDKITE_BUILD_NUMBER}" if a certain pipeline is included, and NODE_IMAGE="node-1.0.0" if it's not