### PR TITLE
build: add NPM_TOKEN secret from Secrets Manager

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,3 +35,6 @@ steps:
     plugins:
       - docker-compose#v3.7.0:
           run: node
+      - seek-oss/aws-sm#v2.2.1:
+          env:
+            NPM_TOKEN: "global/npm-token"


### PR DESCRIPTION
NPM_TOKEN was removed from the default secrets, so we have to include it explicitly.

Should fix the broken master builds.