### PR TITLE
feat: PIPELINE_RUN_ONLY=component-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
   - [Buildkite API Access Token](#buildkite-api-access-token)
 - [Advanced Usage](#advanced-usage)
   - [Controlling what is included](#controlling-what-is-included)
+    - [PIPELINE_RUN_ALL](#pipeline_run_all)
+    - [PIPELINE_RUN_ONLY](#pipeline_run_only)
+    - [PIPELINE_RUN_\*, PIPELINE_NO_RUN_\*](#pipeline_run_-pipeline_no_run_)
   - [Pipeline file changes match themselves](#pipeline-file-changes-match-themselves)
   - [Phony deps](#phony-deps)
   - [Depends On](#depends-on)
@@ -79,9 +82,21 @@ _agent_ token.
 
 ### Controlling what is included
 
+These rules are applied in the order listed here.
+
+#### PIPELINE_RUN_ALL
+
 If you set the environment variable `PIPELINE_RUN_ALL=1`, all parts of the
 pipeline will be output; this is a good way to "force a full build", or disable
 monofo temporarily.
+
+#### PIPELINE_RUN_ONLY
+
+If you set `PIPELINE_RUN_ONLY=component-name`, that component will be included,
+and others excluded, regardless of matches. Pipeline-level `depends_on` will
+still be respected.
+
+#### PIPELINE_RUN_\*, PIPELINE_NO_RUN_\*
 
 If you set `PIPELINE_RUN_<COMPONENT_NAME>=1`, that component will be included,
 even if it wouldn't ordinarily. And if you set `PIPELINE_NO_RUN_<COMPONENT_NAME>`

--- a/src/cmd/pipeline.test.ts
+++ b/src/cmd/pipeline.test.ts
@@ -45,7 +45,7 @@ describe('monofo pipeline', () => {
       .then((p) => {
         expect(p).toBeDefined();
         expect(p.steps.map((s) => s.command)).toStrictEqual([
-          "echo 'inject for: excluded, bar, qux'",
+          "echo 'inject for: excluded, bar, qux, some-long-name'",
           'echo "changed" > changed',
           'echo "dependedon" > dependedon',
           'echo "foo1" > foo1',
@@ -89,7 +89,11 @@ describe('monofo pipeline', () => {
   });
 
   it('can be executed with a PIPELINE_RUN_ONLY environment variable', async () => {
-    process.env = fakeProcess({ PIPELINE_RUN_ONLY: 'bar' });
+    process.env = fakeProcess({
+      PIPELINE_RUN_ONLY: 'bar',
+      PIPELINE_RUN_SOME_LONG_NAME: '1',
+      PIPELINE_NO_RUN_INCLUDED: '1',
+    });
     process.chdir(path.resolve(__dirname, '../../test/projects/kitchen-sink'));
 
     const args: Arguments<unknown> = { $0: '', _: [] };
@@ -101,6 +105,7 @@ describe('monofo pipeline', () => {
           "echo 'inject for: changed, dependedon, excluded, foo, included, qux, baz, unreferenced'",
           'echo "bar1" | tee bar1',
           'echo "bar2" | tee bar2',
+          'echo "some-long-name" > some-long-name',
         ]);
         const { plugins } = p.steps[0];
         expect(plugins ? plugins[0]['artifacts#v1.3.0'] : null).toStrictEqual({

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,10 +9,9 @@ describe('getConfig()', () => {
 
   it('reads pipeline files and returns an array of config files - simple', async () => {
     process.chdir(path.resolve(__dirname, '../test/projects/kitchen-sink'));
-    const config = await getConfigs();
-
-    expect(config).toHaveLength(9);
-    expect(config.map((c) => c.monorepo.name)).toStrictEqual([
+    const configNames = (await getConfigs()).map((c) => c.monorepo.name);
+    expect(configNames).toHaveLength(10);
+    expect(configNames).toStrictEqual([
       'changed',
       'dependedon',
       'excluded',
@@ -21,6 +20,7 @@ describe('getConfig()', () => {
       'included',
       'qux',
       'baz',
+      'some-long-name',
       'unreferenced',
     ]);
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,6 +192,7 @@ declare global {
       BUILDKITE_SOURCE: string;
       BUILDKITE_API_ACCESS_TOKEN: string;
       PIPELINE_RUN_ALL?: string;
+      PIPELINE_RUN_ONLY?: string;
     }
   }
 }

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -32,10 +32,15 @@ describe('matchConfigs', () => {
   it('matches changed files against configs', async () => {
     process.env = fakeProcess();
     process.chdir(path.resolve(__dirname, '../test/projects/kitchen-sink'));
-    const result = matchConfigs('foo', await getConfigs(), ['foo/abc.js', 'foo/README.md', 'bar/abc.ts', 'baz/abc.ts']);
+    const changes = matchConfigs('foo', await getConfigs(), [
+      'foo/abc.js',
+      'foo/README.md',
+      'bar/abc.ts',
+      'baz/abc.ts',
+    ]).map((r) => r.changes);
 
-    expect(result).toHaveLength(9);
-    expect(result.map((r) => r.changes)).toStrictEqual([
+    expect(changes).toHaveLength(10);
+    expect(changes).toStrictEqual([
       [],
       [],
       ['foo/README.md'],
@@ -44,6 +49,7 @@ describe('matchConfigs', () => {
       [],
       [],
       ['baz/abc.ts'],
+      [],
       ['foo/abc.js', 'foo/README.md', 'bar/abc.ts', 'baz/abc.ts'],
     ]);
   });

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import _ from 'lodash';
-import { getMergeDecision, updateDecisionsForDependsOn } from './decide';
+import { getAllDecisions } from './decide';
 import { ARTIFACT_INJECTION_STEP_KEY, artifactInjectionSteps, nothingToDoSteps } from './steps';
 
 const log = debug('monofo:merge');
@@ -60,16 +60,7 @@ function toPipeline(steps: Step[]): Pipeline {
  */
 export default function mergePipelines(results: ConfigWithChanges[]): Pipeline {
   log(`Merging ${results.length} pipelines`);
-
-  const decisions: ConfigWithDecision[] = results.map((r) => {
-    return {
-      ...r,
-      ...getMergeDecision(r),
-    } as ConfigWithDecision;
-  });
-
-  // Mutate for depends_on
-  updateDecisionsForDependsOn(decisions);
+  const decisions: ConfigWithDecision[] = getAllDecisions(results);
 
   // Announce decisions
   decisions.forEach((config) => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -6,7 +6,7 @@ export const BRANCH = 'main';
 export const COMMIT = 'f993bd4d8d59b9c70c8092d327c6ac1c6a263b1f';
 export const BUILD_ID = 'f62a1b4d-10f9-4790-bc1c-e2c3a0c80983';
 
-export function fakeProcess(): NodeJS.ProcessEnv {
+export function fakeProcess(merge: Record<string, string> = {}): NodeJS.ProcessEnv {
   return {
     BUILDKITE_BRANCH: BRANCH,
     BUILDKITE_COMMIT: COMMIT,
@@ -19,6 +19,8 @@ export function fakeProcess(): NodeJS.ProcessEnv {
     // Example values of including a component named 'included', and excluding one called 'excluded'
     PIPELINE_RUN_INCLUDED: 'true',
     PIPELINE_NO_RUN_EXCLUDED: 'true',
+
+    ...merge,
   };
 }
 

--- a/test/projects/kitchen-sink/.buildkite/pipeline.some-long-name.yml
+++ b/test/projects/kitchen-sink/.buildkite/pipeline.some-long-name.yml
@@ -1,0 +1,5 @@
+monorepo: {}
+
+steps:
+  - command: 'echo "some-long-name" > some-long-name'
+    key: some-long-name


### PR DESCRIPTION
- Adds support for PIPELINE_RUN_ONLY=component-name
- Adds a test for PIPELINE_NO_RUN=*
- Adds a regression test for multiple dashes in the component name

Longer term but not done here, we should probably move to `PIPELINE_RUN='foo bar baz'` or something, so that all the env vars work the same (component name in value not key)