### PR TITLE
feat: track when a pipeline has matched everything, and don't list all the files

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -119,12 +119,13 @@ export default class Config {
    * Includes this file
    */
   private matches(): MatchResult {
-    const matches = this.monorepo.matches === true ? ['**/*'] : [...this.monorepo.matches, this.file.path];
+    const matchesAll = Config.matchesAll(this.monorepo.matches);
 
-    return {
-      matchesAll: Config.matchesAll(this.monorepo.matches),
-      files: [...matches, this.file.path],
-    };
+    if (typeof this.monorepo.matches === 'boolean') {
+      return { files: this.monorepo.matches ? ['**/*'] : [this.file.path], matchesAll };
+    }
+
+    return { files: [...this.monorepo.matches, this.file.path], matchesAll };
   }
 
   /**

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -1,10 +1,14 @@
 /* eslint-disable no-param-reassign */
 
 import { CacheMetadataKey, CacheMetadataRepository } from './cache-metadata';
-import Config from './config';
+import Config, { MatchResult } from './config';
 import { service } from './dynamodb';
 import { FileHasher } from './hash';
 import { count } from './util';
+
+function prettyPrintChangeResult(changes: MatchResult): string {
+  return changes.matchesAll ? 'all files match' : changes.files.join(', ');
+}
 
 /**
  * If a config has changes, its steps are merged into the final build. Otherwise, it is excluded, and its excluded_steps
@@ -12,8 +16,11 @@ import { count } from './util';
  */
 function updateDecisionsForChanges(configs: Config[]): void {
   configs.forEach((config) => {
-    if (config.changes.length > 0) {
-      config.decide(true, `${count(config.changes, 'matching change')}: ${config.changes.join(', ')}`);
+    if (config.changes.files.length > 0) {
+      config.decide(
+        true,
+        `${count(config.changes.files, 'matching change')}: ${prettyPrintChangeResult(config.changes)}`
+      );
     }
   });
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -94,8 +94,8 @@ export function matchConfigs(buildId: string, configs: Config[], changedFiles: s
     config.setBuildId(buildId);
     config.updateMatchingChanges(changedFiles);
 
-    if (config.changes.length > 1) {
-      log(`Found ${count(config.changes, 'matching change')} for ${config.monorepo.name}`);
+    if (config.changes.files.length > 1) {
+      log(`Found ${count(config.changes.files, 'matching change')} for ${config.monorepo.name}`);
     }
   });
 }

--- a/test/cmd/pipeline.test.ts
+++ b/test/cmd/pipeline.test.ts
@@ -74,6 +74,9 @@ describe('monofo pipeline', () => {
           'echo "foo1" > foo1',
           "echo 'bar was replaced'",
           'echo "included" > included',
+          'echo "match-all" > match-all',
+          'echo "match-all-boolean" > match-all-boolean',
+          'echo "match-all-mixed" > match-all-mixed',
           'echo "baz1"',
           'echo "unreferenced" > unref',
         ]);
@@ -113,7 +116,7 @@ describe('monofo pipeline', () => {
       .then((p) => {
         expect(p).toBeDefined();
         expect(commandSummary(p.steps)).toStrictEqual([
-          "echo 'inject for: changed, dependedon, excluded, foo, qux, baz, unreferenced'",
+          "echo 'inject for: changed, dependedon, excluded, foo, match-all, match-all-boolean, match-all-mixed, qux, baz, unreferenced'",
           'echo "bar1" | tee bar1',
           'echo "bar2" | tee bar2',
           'echo "included" > included',
@@ -147,6 +150,9 @@ describe('monofo pipeline', () => {
           'echo "dependedon" > dependedon',
           "echo 'bar was replaced'",
           'echo "included" > included',
+          'echo "match-all" > match-all',
+          'echo "match-all-boolean" > match-all-boolean',
+          'echo "match-all-mixed" > match-all-mixed',
           'echo "qux1"',
           'echo "baz1"',
           'echo "some-long-name" > some-long-name',

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -14,7 +14,7 @@ describe('getConfig()', () => {
     const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/kitchen-sink'))).map(
       (c) => c.monorepo.name
     );
-    expect(configNames).toHaveLength(10);
+    expect(configNames).toHaveLength(13);
     expect(configNames).toStrictEqual([
       'changed',
       'dependedon',
@@ -22,6 +22,9 @@ describe('getConfig()', () => {
       'foo',
       'bar',
       'included',
+      'match-all',
+      'match-all-boolean',
+      'match-all-mixed',
       'qux',
       'baz',
       'some-long-name',

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -37,7 +37,7 @@ describe('matchConfigs', () => {
     matchConfigs('foo', configs, ['foo/abc.js', 'foo/README.md', 'bar/abc.ts', 'baz/abc.ts']);
     const changes = configs.map((r) => r.changes);
 
-    expect(changes).toHaveLength(10);
+    expect(changes).toHaveLength(13);
     expect(changes).toStrictEqual([
       [],
       [],
@@ -45,6 +45,9 @@ describe('matchConfigs', () => {
       ['foo/README.md'],
       [],
       [],
+      ['foo/abc.js', 'foo/README.md', 'bar/abc.ts', 'baz/abc.ts'],
+      ['foo/abc.js', 'foo/README.md', 'bar/abc.ts', 'baz/abc.ts'],
+      ['foo/abc.js', 'foo/README.md', 'bar/abc.ts', 'baz/abc.ts'],
       [],
       ['baz/abc.ts'],
       [],

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -35,7 +35,7 @@ describe('matchConfigs', () => {
     process.chdir(path.resolve(__dirname, './projects/kitchen-sink'));
     const configs = await Config.getAll(process.cwd());
     matchConfigs('foo', configs, ['foo/abc.js', 'foo/README.md', 'bar/abc.ts', 'baz/abc.ts']);
-    const changes = configs.map((r) => r.changes);
+    const changes = configs.map((r) => r.changes.files);
 
     expect(changes).toHaveLength(13);
     expect(changes).toStrictEqual([

--- a/test/projects/kitchen-sink/.buildkite/pipeline.match-all-boolean.yml
+++ b/test/projects/kitchen-sink/.buildkite/pipeline.match-all-boolean.yml
@@ -1,0 +1,5 @@
+monorepo:
+  matches: true
+
+steps:
+  - command: echo "match-all-boolean" > match-all-boolean

--- a/test/projects/kitchen-sink/.buildkite/pipeline.match-all-mixed.yml
+++ b/test/projects/kitchen-sink/.buildkite/pipeline.match-all-mixed.yml
@@ -1,0 +1,7 @@
+monorepo:
+  matches:
+    - "**/*"
+    - "**"
+
+steps:
+  - command: echo "match-all-mixed" > match-all-mixed

--- a/test/projects/kitchen-sink/.buildkite/pipeline.match-all.yml
+++ b/test/projects/kitchen-sink/.buildkite/pipeline.match-all.yml
@@ -1,0 +1,5 @@
+monorepo:
+  matches: '**'
+
+steps:
+  - command: echo "match-all" > match-all


### PR DESCRIPTION
This is a small display improvement which stops the output from listing all the files in the repo multiple times when there are pipelines that match everything.

It also adds support for `matches: true`