### PR TITLE
feat: add commands to list and hash components

### DIFF
--- a/src/cmd/hash.ts
+++ b/src/cmd/hash.ts
@@ -1,6 +1,4 @@
 import { Arguments, CommandModule } from 'yargs';
-import { getBuildkiteInfo } from '../buildkite/config';
-import { getBaseBuild } from '../diff';
 import Config from '../config';
 import { FileHasher } from '../hash';
 
@@ -10,8 +8,7 @@ interface HashArgs {
 
 const cmd: CommandModule = {
   command: 'hash <componentName>',
-  describe: 'List matching files for different parts of the pipeline',
-  aliases: ['ls'],
+  describe: 'Return the content hash for matching files of a part of the pipeline',
   builder: (yargs) =>
     yargs
       .positional('componentName', {
@@ -20,7 +17,7 @@ const cmd: CommandModule = {
         required: true
       }),
 
-  async handler(args): Promise<void> {
+  async handler(args): Promise<string> {
     const { componentName } = args as Arguments<HashArgs>;
     const config: Config | undefined = await Config.getOne(process.cwd(), componentName)
 
@@ -34,6 +31,7 @@ const cmd: CommandModule = {
     const hash = await config.getContentHash(hasher)
 
     process.stdout.write(`${hash}\n`);
+    return `${hash}\n`
   }
 };
 

--- a/src/cmd/hash.ts
+++ b/src/cmd/hash.ts
@@ -1,0 +1,40 @@
+import { Arguments, CommandModule } from 'yargs';
+import { getBuildkiteInfo } from '../buildkite/config';
+import { getBaseBuild } from '../diff';
+import Config from '../config';
+import { FileHasher } from '../hash';
+
+interface HashArgs {
+  componentName: string
+}
+
+const cmd: CommandModule = {
+  command: 'hash <componentName>',
+  describe: 'List matching files for different parts of the pipeline',
+  aliases: ['ls'],
+  builder: (yargs) =>
+    yargs
+      .positional('componentName', {
+        describe: 'Name of the component that was successful',
+        type: 'string',
+        required: true
+      }),
+
+  async handler(args): Promise<void> {
+    const { componentName } = args as Arguments<HashArgs>;
+    const config: Config | undefined = await Config.getOne(process.cwd(), componentName)
+
+    if (!config) {
+      const e = new Error('Could not read component configuration')
+      process.stderr.write(`${e.message}\n`);
+      return Promise.reject(e)
+    }
+
+    const hasher = new FileHasher();
+    const hash = await config.getContentHash(hasher)
+
+    process.stdout.write(`${hash}\n`);
+  }
+};
+
+export = cmd;

--- a/src/cmd/list.ts
+++ b/src/cmd/list.ts
@@ -1,6 +1,4 @@
 import { Arguments, CommandModule } from 'yargs';
-import { getBuildkiteInfo } from '../buildkite/config';
-import { getBaseBuild } from '../diff';
 import Config from '../config';
 
 interface ListArgs {

--- a/src/cmd/list.ts
+++ b/src/cmd/list.ts
@@ -19,7 +19,7 @@ const cmd: CommandModule = {
         required: true
       }),
 
-  async handler(args): Promise<void> {
+  async handler(args): Promise<string> {
     const { componentName } = args as Arguments<ListArgs>;
     const config: Config | undefined = await Config.getOne(process.cwd(), componentName)
 
@@ -30,10 +30,10 @@ const cmd: CommandModule = {
     }
 
     const matching = await config.getMatchingFiles()
+    const output = matching.files.join("\n")
 
-    matching.files.forEach((match) => {
-      process.stdout.write(`${match}\n`);
-    })
+    process.stdout.write(`${output}\n`);
+    return output
   }
 };
 

--- a/test/cmd/hash.test.ts
+++ b/test/cmd/hash.test.ts
@@ -1,24 +1,24 @@
 import path from 'path';
 import { Arguments } from 'yargs';
-import * as list from '../../src/cmd/list';
+import * as hash from '../../src/cmd/hash';
 import { fakeProcess } from '../fixtures';
 import execSync from './exec';
 
 jest.mock('../../src/git');
 jest.mock('../../src/buildkite/client');
 
-describe('monofo list', () => {
+describe('monofo hash', () => {
   it('returns help output', async () => {
-    const output = await execSync(list, 'list --help');
-    expect(output).toContain('List matching files');
+    const output = await execSync(hash, 'list --help');
+    expect(output).toContain('Return the content hash');
   });
 
-  it('returns matching files for the pure scenario', async () => {
+  it('returns the content hash for the pure scenario', async () => {
     process.env = fakeProcess();
     process.chdir(path.resolve(__dirname, '../projects/pure'));
 
     const args: Arguments<unknown> = { $0: '', _: [], componentName: 'foo' };
-    const output = await ((list.handler(args) as unknown) as Promise<string>)
-    expect(output).toContain('foo/README.md')
+    const output = await ((hash.handler(args) as unknown) as Promise<string>)
+    expect(output).toContain('0ffe034c45380e93a2f65d67d8c286a237b00285233c91b778ba70f860c7b54a')
   });
 });

--- a/test/cmd/list.test.ts
+++ b/test/cmd/list.test.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import { load as loadYaml } from 'js-yaml';
+import _ from 'lodash';
+import { mocked } from 'ts-jest/utils';
+import { Arguments } from 'yargs';
+import { CacheMetadataRepository } from '../../src/cache-metadata';
+import * as list from '../../src/cmd/list';
+import { service } from '../../src/dynamodb';
+import { mergeBase, diff, revList } from '../../src/git';
+import { BUILD_ID, BUILD_ID_2, BUILD_ID_3, COMMIT, fakeProcess } from '../fixtures';
+import execSync from './exec';
+
+jest.mock('../../src/git');
+jest.mock('../../src/buildkite/client');
+
+describe('monofo list', () => {
+  it('returns help output', async () => {
+    const output = await execSync(list, 'list --help');
+    expect(output).toContain('List matching files');
+  });
+
+  it('returns matching files for the pure scenario', async () => {
+    process.env = fakeProcess();
+    process.chdir(path.resolve(__dirname, '../projects/pure'));
+
+    const args: Arguments<unknown> = { $0: '', _: [], componentName: 'foo' };
+    const output = await ((list.handler(args) as unknown) as Promise<string>)
+    expect(output).toContain('foo/README.md')
+  });
+});


### PR DESCRIPTION
Adds two new commands, `list` and `hash`. These use the globbing and matching logic, but allow other tools to do things with the list of files, or the content hash