### PR TITLE
build(docker): change build-cache repository to ECR

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ env:
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL: "true"
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY: "quay.io/vital/build-cache"
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY: "239595706494.dkr.ecr.us-west-2.amazonaws.com/build-cache"
 
 steps:
   - label: ":docker:"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       context: .
       args:
         - NODE_TAG=lts
-    image: quay.io/vital/build-cache:monofo-node-latest
+    image: 239595706494.dkr.ecr.us-west-2.amazonaws.com/build-cache:monofo-node-latest
 
   node-14:
     build:
       context: .
       args:
         - NODE_TAG=14
-    image: quay.io/vital/build-cache:monofo-node-14-latest
+    image: 239595706494.dkr.ecr.us-west-2.amazonaws.com/build-cache:monofo-node-14-latest


### PR DESCRIPTION
Moved away from Quay

Fixes build failures seen in renovate branches. Was missed from original migration because I was only looking for private repos.