### PR TITLE
feat(config): make matches: false ignore self-changes to its pipeline

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -35,7 +35,11 @@ function updateDecisionsForChanges(configs: Config[]): void {
 function updateDecisionsForEnvVars(configs: Config[]): void {
   configs.forEach((config) => {
     if (process.env.PIPELINE_RUN_ALL) {
-      config.decide(true, 'been forced to by PIPELINE_RUN_ALL');
+      if (config.monorepo.matches === false) {
+        config.decide(false, 'opted-out of PIPELINE_RUN_ALL via monorepo.matches === false');
+      } else {
+        config.decide(true, 'been forced to by PIPELINE_RUN_ALL');
+      }
     }
 
     if (process.env?.PIPELINE_RUN_ONLY) {


### PR DESCRIPTION
When providing `matches: false` with an explicit boolean, take this to mean that we shouldn't then automatically add the pipeline.yml file to the list of matches. That'll prevent it running when modified.

Also excludes such pipelines from `PIPELINE_RUN_ALL`

Fixes #195
Fixes #198