### PR TITLE
feat(config): print warning log when invalid attributes are found

### DIFF
--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -31,4 +31,14 @@ describe('getConfig()', () => {
       'unreferenced',
     ]);
   });
+
+  it('reads pipeline files and returns an array of config files - invalid', async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/invalid'))).map(
+      (c) => c.monorepo.name
+    );
+    expect(configNames).toHaveLength(1);
+    expect(configNames).toStrictEqual([
+      'invalid',
+    ]);
+  });
 });

--- a/test/projects/invalid/pipeline.invalid.yml
+++ b/test/projects/invalid/pipeline.invalid.yml
@@ -1,0 +1,7 @@
+monorepo:
+  produced: '<- wrong key'
+  matched: '<- wrong key'
+  depended_on: '<- wrong key'
+
+env: {}
+steps: []


### PR DESCRIPTION
Small usability feature. Checks the `monorepo` config against an expected list of properties (built from the type `MonorepoConfig`)

Fixes #188