### PR TITLE
fix(config): fallback for never-matched tasks should be excluded, not included

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -66,7 +66,11 @@ function updateDecisionsForEnvVars(configs: Config[]): void {
 function updateDecisionsFoFallback(configs: Config[]): void {
   configs.forEach((config) => {
     if (!config.buildId) {
-      config.decide(true, 'no previous successful build, fallback to being included');
+      if (config.monorepo.matches === false) {
+        config.decide(false, 'no previous successful build, task fallback to being excluded');
+      } else {
+        config.decide(true, 'no previous successful build, fallback to being included');
+      }
     }
   });
 }


### PR DESCRIPTION
If `matches === false`, the fallback should be for this component to be excluded, because it usually
represents a task that can only otherwise be run with `PIPELINE_RUN_` env vars.

Put another way, this means that monofo won't make all the _task_ pipelines run when there's no base build found (due to an error or a fresh pipeline etc.)