### PR TITLE
refactor(config): simplify the matching interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 logs
 docker-compose.*override.yml
 .idea/
+output/

--- a/src/cmd/list.ts
+++ b/src/cmd/list.ts
@@ -30,7 +30,7 @@ const cmd: Command<ListArgs> = {
     }
 
     const matching = await config.getMatchingFiles();
-    const output = matching.files.join('\n');
+    const output = matching.join('\n');
 
     process.stdout.write(`${output}\n`);
     return output;

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -161,8 +161,8 @@ export function matchConfigs(buildId: string, configs: Config[], changedFiles: s
     config.setBuildId(buildId);
     config.updateMatchingChanges(changedFiles);
 
-    if (config.changes.files.length > 1) {
-      log(`Found ${count(config.changes.files, 'matching change')} for ${config.monorepo.name}`);
+    if (config.changes.length > 1) {
+      log(`Found ${count(config.changes, 'matching change')} for ${config.monorepo.name}`);
     }
   });
 }

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -80,7 +80,7 @@ describe('matchConfigs', () => {
       process.chdir(path.resolve(__dirname, './projects/kitchen-sink'));
       const configs = await Config.getAll(process.cwd());
       matchConfigs('foo', configs, changedFiles);
-      const changes = configs.map((r) => r.changes.files);
+      const changes = configs.map((r) => r.changes);
 
       expect(changes).toHaveLength(14);
       expect(changes).toStrictEqual([
@@ -110,7 +110,7 @@ describe('matchConfigs', () => {
       process.chdir(path.resolve(__dirname, './projects/kitchen-sink'));
       const configs = await Config.getAll(process.cwd());
       matchConfigs('foo', configs, changedFiles);
-      const changes = configs.map((r) => r.changes.files);
+      const changes = configs.map((r) => r.changes);
 
       expect(changes).toHaveLength(14);
       expect(changes).toStrictEqual([[], [], [], [], [], [], [], [], [], [], [], [], [], []]);


### PR DESCRIPTION
Removes the `MatchResult` interface, because we don't actually have anything reading `matchesAll`/`matchesNone` anymore; anything that was reading it can instead access `config.monorepo.matches` (the raw `boolean | string[]`).