### PR TITLE
[KATOA-3413] Add logic for branch inclusion/exclusion and tests

### DIFF
--- a/src/branch-list.ts
+++ b/src/branch-list.ts
@@ -1,0 +1,22 @@
+import _ from 'lodash';
+
+export interface ParsedBranchList {
+  allowed: string[];
+  blocked: string[];
+}
+
+export function parseBranchList(branchList?: string): ParsedBranchList {
+  if (!branchList) {
+    return {
+      allowed: [],
+      blocked: [],
+    };
+  }
+
+  const [allowed, blocked] = _.partition(branchList.split(' '), (item) => item.indexOf('!'));
+
+  return {
+    allowed,
+    blocked,
+  };
+}

--- a/test/branch-list.test.ts
+++ b/test/branch-list.test.ts
@@ -1,0 +1,71 @@
+import path from 'path';
+import Config from '../src/config';
+
+describe('branchFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows the main branch', async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('main');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual(['explicit-all', 'implicit-all', 'implicit-rest']);
+  });
+
+  it('allows a random feature branch', async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('feature/allowed-feature');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual([
+      'explicit-all',
+      'explicit-include-exclude',
+      'explicit-include-exclude-wildcard',
+      'explicit-wildcards',
+      'implicit-all',
+      'implicit-rest',
+    ]);
+  });
+
+  it("doesn't allow a excluded feature branch", async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('feature/excluded');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual(['explicit-all', 'explicit-wildcards', 'implicit-all', 'implicit-rest']);
+  });
+
+  it("doesn't allow a excluded feature branch by wildcard", async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('feature/excluded-name');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual([
+      'explicit-all',
+      'explicit-include-exclude',
+      'explicit-wildcards',
+      'implicit-all',
+      'implicit-rest',
+    ]);
+  });
+
+  it('allows a single branch', async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('one');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual(['explicit-all', 'explicit-one', 'implicit-all']);
+  });
+});

--- a/test/branch-list.test.ts
+++ b/test/branch-list.test.ts
@@ -25,6 +25,7 @@ describe('branchFilter', () => {
 
     expect(configNames).toStrictEqual([
       'explicit-all',
+      'explicit-exclude-multiple',
       'explicit-include-exclude',
       'explicit-include-exclude-wildcard',
       'explicit-wildcards',
@@ -40,7 +41,13 @@ describe('branchFilter', () => {
       })
       .map((c) => c.monorepo.name);
 
-    expect(configNames).toStrictEqual(['explicit-all', 'explicit-wildcards', 'implicit-all', 'implicit-rest']);
+    expect(configNames).toStrictEqual([
+      'explicit-all',
+      'explicit-exclude-multiple',
+      'explicit-wildcards',
+      'implicit-all',
+      'implicit-rest',
+    ]);
   });
 
   it("doesn't allow a excluded feature branch by wildcard", async () => {
@@ -52,6 +59,7 @@ describe('branchFilter', () => {
 
     expect(configNames).toStrictEqual([
       'explicit-all',
+      'explicit-exclude-multiple',
       'explicit-include-exclude',
       'explicit-wildcards',
       'implicit-all',
@@ -68,6 +76,7 @@ describe('branchFilter', () => {
 
     expect(configNames).toStrictEqual([
       'explicit-all',
+      'explicit-exclude-multiple',
       'explicit-include-exclude',
       'explicit-include-exclude-wildcard',
       'explicit-wildcard-end',
@@ -86,8 +95,44 @@ describe('branchFilter', () => {
 
     expect(configNames).toStrictEqual([
       'explicit-all',
+      'explicit-exclude-multiple',
       'explicit-include-exclude',
       'explicit-include-exclude-wildcard',
+      'explicit-wildcards',
+      'implicit-all',
+      'implicit-rest',
+    ]);
+  });
+
+  it('allows a single feature branch when multiple included', async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('feature/include-one');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual([
+      'explicit-all',
+      'explicit-exclude-multiple',
+      'explicit-include-exclude',
+      'explicit-include-exclude-wildcard',
+      'explicit-include-multiple',
+      'explicit-wildcards',
+      'implicit-all',
+      'implicit-rest',
+    ]);
+  });
+
+  it("doesn't allow a single feature branch when multiple excluded", async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('feature/exclude-one');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual([
+      'explicit-all',
+      'explicit-include-exclude',
       'explicit-wildcards',
       'implicit-all',
       'implicit-rest',

--- a/test/branch-list.test.ts
+++ b/test/branch-list.test.ts
@@ -59,6 +59,41 @@ describe('branchFilter', () => {
     ]);
   });
 
+  it('allows a wildcard-included feature branch', async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('feature/name-included');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual([
+      'explicit-all',
+      'explicit-include-exclude',
+      'explicit-include-exclude-wildcard',
+      'explicit-wildcard-end',
+      'explicit-wildcards',
+      'implicit-all',
+      'implicit-rest',
+    ]);
+  });
+
+  it("doesn't allow a wildcard-excluded feature branch", async () => {
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
+      .filter((config) => {
+        return config.includedInBranchList('feature/name-excluded');
+      })
+      .map((c) => c.monorepo.name);
+
+    expect(configNames).toStrictEqual([
+      'explicit-all',
+      'explicit-include-exclude',
+      'explicit-include-exclude-wildcard',
+      'explicit-wildcards',
+      'implicit-all',
+      'implicit-rest',
+    ]);
+  });
+
   it('allows a single branch', async () => {
     const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/branch-exclusion')))
       .filter((config) => {

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-all.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-all.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes all branches explicitly because wildcard
+  branches: '*'
+
+steps:
+  - command: echo "explicit-all" > explicit-all
+    key: explicit-all

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-exclude-multiple.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-exclude-multiple.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes some branches by wildcards, if not excluded by other wildcards
+  branches: 'feature/* !feature/exclude-one !feature/exclude-two !feature/exclude-three'
+
+steps:
+  - command: echo "explicit-include-exclude-wildcard" > explicit-include-exclude-wildcard
+    key: explicit-include-exclude-wildcard

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-include-exclude-wildcard.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-include-exclude-wildcard.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes some branches by wildcards, if not excluded by other wildcards
+  branches: 'feature/* !feature/exclude*'
+
+steps:
+  - command: echo "explicit-include-exclude-wildcard" > explicit-include-exclude-wildcard
+    key: explicit-include-exclude-wildcard

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-include-exclude.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-include-exclude.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes some branches by wildcards, if not excluded by other wildcards
+  branches: 'feature/* !feature/excluded'
+
+steps:
+  - command: echo "explicit-include-exclude" > explicit-include-exclude
+    key: explicit-include-exclude

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-include-multiple.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-include-multiple.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes some branches by wildcards, if not excluded by other wildcards
+  branches: 'feature/include-one feature/include-two feature/include-three'
+
+steps:
+  - command: echo "explicit-include-exclude-wildcard" > explicit-include-exclude-wildcard
+    key: explicit-include-exclude-wildcard

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-none.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-none.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This excludes all branches explicitly because wildcard
+  branches: '!*'
+
+steps:
+  - command: echo "explicit-none" > explicit-none
+    key: explicit-none

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-one.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-one.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes one branch (only) explicitly
+  branches: 'one'
+
+steps:
+  - command: echo "explicit-one" > explicit-one
+    key: explicit-one

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-wildcard-end.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-wildcard-end.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes some branches by wildcards, if not excluded by other wildcards
+  branches: 'feature/*-included !feature/*-excluded'
+
+steps:
+  - command: echo "explicit-wildcard-end" > explicit-wildcard-end
+    key: explicit-wildcard-end

--- a/test/projects/branch-exclusion/.buildkite/pipeline.explicit-wildcards.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.explicit-wildcards.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This includes some branches by wildcards
+  branches: 'feature/*'
+
+steps:
+  - command: echo "explicit-wildcards" > explicit-wildcards
+    key: explicit-wildcards

--- a/test/projects/branch-exclusion/.buildkite/pipeline.implicit-all.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.implicit-all.yml
@@ -1,0 +1,8 @@
+monorepo:
+  matches: '**'
+
+  # This includes all branches implicitly because branches not defined
+
+steps:
+  - command: echo "implicit-all" > implicit-all
+    key: implicit-all

--- a/test/projects/branch-exclusion/.buildkite/pipeline.implicit-rest.yml
+++ b/test/projects/branch-exclusion/.buildkite/pipeline.implicit-rest.yml
@@ -1,0 +1,9 @@
+monorepo:
+  matches: '**'
+
+  # This excludes one branch explicitly, and includes the rest implicitly
+  branches: '!one'
+
+steps:
+  - command: echo "implicit-rest" > implicit-rest
+    key: implicit-rest


### PR DESCRIPTION
We would like the Buildkite branch filtering patterns (https://buildkite.com/docs/pipelines/branch-configuration#pipeline-level-branch-filtering), but set on a pipeline level so that we can still make use of (potential) artifacts produced by said pipelines. This requires the logic to go through monofo