### PR TITLE
fix(diff): fix integration strategy to check for existing commits with cat-file

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -31,6 +31,8 @@ export function revList(...args: string[]): Promise<string[]> {
   return git('rev-list', ...args).then((v) => v.trim().split('\n'));
 }
 
-export function revParse(...args: string[]): Promise<string> {
-  return git('rev-parse', ...args).then((v) => v.trim());
+export function commitExists(commit: string): Promise<boolean> {
+  return git('cat-file', '-e', `${commit}^{commit}`)
+    .then(() => true)
+    .catch(() => false);
 }

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -3,7 +3,7 @@ import { mocked } from 'ts-jest/utils';
 import { getBuildkiteInfo } from '../src/buildkite/config';
 import Config from '../src/config';
 import { getBaseBuild, matchConfigs } from '../src/diff';
-import { mergeBase, revList, revParse } from '../src/git';
+import { commitExists, mergeBase, revList } from '../src/git';
 import { BASE_BUILD, COMMIT, fakeProcess } from './fixtures';
 
 jest.mock('../src/git');
@@ -14,8 +14,8 @@ mockRevList.mockImplementation(() => Promise.resolve([COMMIT]));
 
 const mockMergeBase = mocked(mergeBase, true);
 
-const mockRevParse = mocked(revParse, true);
-mockRevParse.mockImplementation((foo) => Promise.resolve(foo));
+const mockCommitExists = mocked(commitExists, true);
+mockCommitExists.mockImplementation(() => Promise.resolve(true));
 
 describe('getBaseBuild', () => {
   beforeEach(() => {


### PR DESCRIPTION
We were using `git rev-parse` to check for existing commits (so that we don't use a commit that no longer exists in the repository as a base build). However, this doesn't validate a SHA-1 hash corresponds to a valid commit: it just accepts *any* valid SHA-1 hash and returns success. Whoops.

![image](https://user-images.githubusercontent.com/97427/142961866-7b424e9c-3739-4836-ab37-f0951b0ad3af.png)

Instead, we should use `git cat-file -e HASH^{commit}` - this ensures that "HASH" can be treated as a commit (because it exists in the object DB)