### PR TITLE
feat(config-file): Allow customizing PIPELINE_FILE_GLOB and PIPELINE_FILE_IGNORE_GLOB

### DIFF
--- a/src/buildkite/config.ts
+++ b/src/buildkite/config.ts
@@ -45,8 +45,13 @@ declare global {
       BUILDKITE_PIPELINE_SLUG: string;
       BUILDKITE_SOURCE: string;
       BUILDKITE_API_ACCESS_TOKEN: string;
+
       PIPELINE_RUN_ALL?: string;
       PIPELINE_RUN_ONLY?: string;
+
+      PIPELINE_FILE_GLOB?: string;
+      PIPELINE_FILE_IGNORE_GLOB?: string;
+
       MONOFO_DEFAULT_BRANCH?: string;
       MONOFO_INTEGRATION_BRANCH?: string;
     }

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -23,11 +23,27 @@ function strings(v: undefined | string[] | string): string[] {
 export default class ConfigFile {
   private static readonly PIPELINE_FILE_REGEX = /^pipeline\.(?<name>.*)\.yml$/;
 
-  private static readonly PIPELINE_FILE_GLOB = '**/pipeline*.yml';
+  private static readonly PIPELINE_FILE_GLOB_DEFAULT = '**/pipeline*.yml';
 
-  private static readonly PIPELINE_FILE_IGNORE_GLOB = ['**/node_modules/**'];
+  private static readonly PIPELINE_FILE_IGNORE_GLOB_DEFAULT = ['**/node_modules/**'];
 
   constructor(public readonly path: string, public readonly basePath = process.cwd()) {}
+
+  private static fileGlob(): string {
+    if (process.env.PIPELINE_FILE_GLOB) {
+      return process.env.PIPELINE_FILE_GLOB;
+    }
+
+    return ConfigFile.PIPELINE_FILE_GLOB_DEFAULT;
+  }
+
+  private static fileIgnoreGlob(): string[] {
+    if (process.env.PIPELINE_FILE_IGNORE_GLOB) {
+      return process.env.PIPELINE_FILE_IGNORE_GLOB.split(':');
+    }
+
+    return ConfigFile.PIPELINE_FILE_IGNORE_GLOB_DEFAULT;
+  }
 
   nameFromFilename(): string | undefined {
     const match = ConfigFile.PIPELINE_FILE_REGEX.exec(basename(this.path));
@@ -39,10 +55,10 @@ export default class ConfigFile {
    */
   static async search(cwd: string = process.cwd()): Promise<ConfigFile[]> {
     try {
-      const pipelines = await glob(ConfigFile.PIPELINE_FILE_GLOB, {
+      const pipelines = await glob(ConfigFile.fileGlob(), {
         dot: true,
         cwd,
-        ignore: ConfigFile.PIPELINE_FILE_IGNORE_GLOB,
+        ignore: ConfigFile.fileIgnoreGlob(),
       });
 
       return pipelines.map((path) => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,7 @@
 import fsCb from 'fs';
 import path from 'path';
 import Config from '../src/config';
+import { fakeProcess } from './fixtures';
 
 const fs = fsCb.promises;
 
@@ -38,5 +39,29 @@ describe('getConfig()', () => {
     const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/invalid'))).map((c) => c.monorepo.name);
     expect(configNames).toHaveLength(1);
     expect(configNames).toStrictEqual(['invalid']);
+  });
+
+  it('reads pipeline files - custom glob', async () => {
+    process.env = fakeProcess({
+      PIPELINE_FILE_GLOB: '**/pipeline.foo*.yml', // excludes foo1
+    });
+
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/flexible-structure'))).map(
+      (c) => c.monorepo.name
+    );
+    expect(configNames).toHaveLength(2);
+    expect(configNames).toStrictEqual(['foo2', 'foo3']);
+  });
+
+  it('reads pipeline files - custom ignore glob', async () => {
+    process.env = fakeProcess({
+      PIPELINE_FILE_IGNORE_GLOB: '**/node_modules/**:foo/**', // excludes foo2
+    });
+
+    const configNames = (await Config.getAll(path.resolve(__dirname, 'projects/flexible-structure'))).map(
+      (c) => c.monorepo.name
+    );
+    expect(configNames).toHaveLength(2);
+    expect(configNames).toStrictEqual(['foo1', 'foo3']);
   });
 });


### PR DESCRIPTION
In preparation for self-hosting (#271), we need to be able to exclude directories of pipeline files per monofo-installation. Specifically, we're interested in excluding our own `test/**/pipeline.*.yml` files that are used as test fixtures.