### PR TITLE
feat: Add a standard way to load monofo via Buildkite plugin configuration

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -19,8 +19,12 @@ steps:
     plugins:
       - improbable-eng/metahook#v0.4.1:
           pre-command: >
-            buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 &
-            buildkite-agent artifact download typescript.tar.lz4 . && tar -x --use-compress-program=lz4 -f typescript.tar.lz4 &
+            buildkite-agent artifact download node-modules.tar.lz4 .
+              && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4
+              && rm -rf node-modules.tar.lz4 &
+            buildkite-agent artifact download typescript.tar.lz4 .
+              && tar -x --use-compress-program=lz4 -f typescript.tar.lz4
+              && rm -rf typescript.tar.lz4 &
             wait
       - docker-compose#v3.9.0:
           run: node

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -19,12 +19,8 @@ steps:
     plugins:
       - improbable-eng/metahook#v0.4.1:
           pre-command: >
-            buildkite-agent artifact download node-modules.tar.lz4 .
-              && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4
-              && rm -rf node-modules.tar.lz4 &
-            buildkite-agent artifact download typescript.tar.lz4 .
-              && tar -x --use-compress-program=lz4 -f typescript.tar.lz4
-              && rm -rf typescript.tar.lz4 &
+            buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 && rm -rf node-modules.tar.lz4 &
+            buildkite-agent artifact download typescript.tar.lz4 . && tar -x --use-compress-program=lz4 -f typescript.tar.lz4 && rm -rf typescript.tar.lz4 &
             wait
       - docker-compose#v3.9.0:
           run: node

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -26,8 +26,8 @@ steps:
     plugins:
       - improbable-eng/metahook#v0.4.1:
           pre-command: >
-            buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 &
-            buildkite-agent artifact download typescript.tar.lz4 . && tar -x --use-compress-program=lz4 -f typescript.tar.lz4 &
+            buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 && rm -rf node-modules.tar.lz4 &
+            buildkite-agent artifact download typescript.tar.lz4 . && tar -x --use-compress-program=lz4 -f typescript.tar.lz4 && rm -rf typescript.tar.lz4 &
             wait
       - docker-compose#v3.9.0:
           run: node

--- a/.buildkite/pipeline.typescript.yml
+++ b/.buildkite/pipeline.typescript.yml
@@ -24,7 +24,7 @@ steps:
     timeout_in_minutes: 20
     plugins:
       - improbable-eng/metahook#v0.4.1:
-          pre-command: buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4
+          pre-command: buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 && rm -rf node-modules.tar.lz4
       - docker-compose#v3.9.0:
           run: node
       - artifacts#v1.5.0:

--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,7 @@ coverage
 *.log
 .editorconfig
 *.tgz
+*.tar.lz4
 .dockerignore
 scripts
 Dockerfile

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ an example to generate your pipeline might be:
 ```yaml
 steps:
   - name: ":pipeline: Generate pipeline"
+    command: echo "Monorepo pipeline uploaded"
     plugins:
       - seek-oss/aws-sm#v2.2.1: # for example, but your secret management might be e.g. via S3 bucket or "env" file instead
           env:

--- a/README.md
+++ b/README.md
@@ -13,21 +13,25 @@ time by only building what you need.
 
 Instead of calling `buildkite-agent pipeline upload` in the first step of a
 pipeline, execute `monofo pipeline` which will output the dynamic pipeline on
-stdout. A good example for what to paste into the Step Editor UI in Buildkite
-might be:
+stdout: `npx monofo pipeline | buildkite-agent pipeline upload`
+
+To make this easier, Monofo supports configuration as a Buildkite plugin, so
+an example to generate your pipeline might be:
 
 ```yaml
 steps:
   - name: ":pipeline: Generate pipeline"
-    command: npx monofo pipeline | buildkite-agent pipeline upload
     plugins:
       - seek-oss/aws-sm#v2.2.1: # for example, but your secret management might be e.g. via S3 bucket or "env" file instead
           env:
             BUILDKITE_API_ACCESS_TOKEN: "global/buildkite-api-access-token"
+      - vital-software/monofo#v2.0.1
+          generate: pipeline
 ```
 
-The only required configuration is the `BUILDKITE_API_ACCESS_TOKEN` environment
-variable. See [Configuration](#configuration) for details.
+Note that Monofo requires an environment variable to be configured, allowing it
+to access the Buildkite API. This is the `BUILDKITE_API_ACCESS_TOKEN`
+environment variable. See [Configuration](#configuration) for details.
 
 ### Splitting pipelines using multiple `pipeline.yml` files
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ steps:
       - seek-oss/aws-sm#v2.2.1: # for example, but your secret management might be e.g. via S3 bucket or "env" file instead
           env:
             BUILDKITE_API_ACCESS_TOKEN: "global/buildkite-api-access-token"
-      - vital-software/monofo#v2.0.1
+      - vital-software/monofo#v2.0.1:
           generate: pipeline
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,14 @@ services:
         type: bind
     image: ${NODE_IMAGE_TAG:-239595706494.dkr.ecr.us-west-2.amazonaws.com/build-cache:monofo-node-main}
 
-  lint:
+  plugin-lint:
     image: buildkite/plugin-linter
     command: ['--id', 'vital-software/monofo']
+    volumes:
+      - ".:/plugin:ro"
+
+  plugin-tests:
+    image: buildkite/plugin-tester
+    command: bats hooks/
     volumes:
       - ".:/plugin:ro"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,9 @@ services:
         target: /monofo
         type: bind
     image: ${NODE_IMAGE_TAG:-239595706494.dkr.ecr.us-west-2.amazonaws.com/build-cache:monofo-node-main}
+
+  lint:
+    image: buildkite/plugin-linter
+    command: ['--id', 'vital-software/monofo']
+    volumes:
+      - ".:/plugin:ro"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Usage: create a pipeline that looks like this:
+#
+# steps:
+#   - name: ":pipeline: Generate pipeline"
+#     plugins:
+#       - seek-oss/aws-sm#v2.2.1: # for example, but your secret management might be e.g. via S3 bucket or "env" file instead
+#           env:
+#             BUILDKITE_API_ACCESS_TOKEN: "global/buildkite-api-access-token"
+#       - vital-software/monofo#<latest>:
+#           generate: pipeline
+#
+# If you had a previous generator, you need to wait until all branches have the
+# script before calling it, or change the command to:
+#
+# git merge-base --is-ancestor <merge-commit-of-generate-pipeline> HEAD && .buildkite/generate-pipeline || ( <previous-command> )
+#
+# This script installs and calls monofo with a static version so the install is
+# cached and fast
+
+set -euo pipefail
+
+MONOFO_VERSION=2.0.1
+BUILDKITE_PLUGIN_MONOFO_GENERATE=${BUILDKITE_PLUGIN_MONOFO_GENERATE:-}
+BUILDKITE_AGENT_ACCESS_TOKEN=${BUILDKITE_AGENT_ACCESS_TOKEN:-}
+
+if [[ -z "${BUILDKITE_PLUGIN_MONOFO_GENERATE}" || "$BUILDKITE_PLUGIN_MONOFO_GENERATE" != "pipeline" ]]; then
+  # Nothing to do: we only generate a pipeline if `generate` is set to `pipeline`
+  exit 0
+fi
+
+PIPELINE_FILE="$(mktemp /tmp/generate-pipeline.XXXXXX)"
+
+# Should be able to figure out version to use from BUILDKITE_PLUGIN_CONFIGURATION
+echo "${BUILDKITE_PLUGIN_CONFIGURATION:-}"
+
+echo "--- Fetching other branches" >&2
+git fetch -v origin +refs/heads/*:refs/remotes/origin/*
+
+echo "+++ :pipeline: Generating..." >&2
+DEBUG="monofo:*" npx "monofo@$MONOFO_VERSION" > "$PIPELINE_FILE"
+
+echo "--- :pipeline: Result" >&2
+cat "$PIPELINE_FILE"
+
+if [[ -n "$BUILDKITE_AGENT_ACCESS_TOKEN" ]]; then
+  echo "--- :pipeline: Upload" >&2
+  buildkite-agent pipeline upload < "$PIPELINE_FILE"
+else
+  echo "Skipping pipeline upload, because no BUILDKITE_AGENT_ACCESS_TOKEN was set: probably not running in Buildkite"
+fi
+
+rm -f "$PIPELINE_FILE"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -20,7 +20,9 @@
 
 set -euo pipefail
 
-MONOFO_VERSION=2.0.1
+# This version marker is automatically updated to match the published release
+MONOFO_VERSION=2.1.1
+
 BUILDKITE_PLUGIN_MONOFO_GENERATE=${BUILDKITE_PLUGIN_MONOFO_GENERATE:-}
 BUILDKITE_AGENT_ACCESS_TOKEN=${BUILDKITE_AGENT_ACCESS_TOKEN:-}
 

--- a/hooks/pre-command.bats
+++ b/hooks/pre-command.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+# Uncomment to enable stub debugging
+export NPX_STUB_DEBUG=/dev/tty
+export GIT_STUB_DEBUG=/dev/tty
+
+@test "calls npx when generating a pipeline" {
+  export BUILDKITE_PLUGIN_MONOFO_GENERATE="pipeline"
+
+  stub npx "monofo@2.0.1 : echo npx output"
+  stub git "* : echo git output"
+
+  run $PWD/hooks/pre-command
+
+  assert_output --partial "git output"
+  assert_output --partial "npx output"
+  assert_success
+
+  unstub npx
+  unstub git
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@commitlint/cli": "15.0.0",
     "@commitlint/config-conventional": "15.0.0",
+    "@google/semantic-release-replace-plugin": "1.1.0",
     "@semantic-release/changelog": "6.0.1",
     "@semantic-release/git": "10.0.1",
     "@tsconfig/node12": "1.0.9",
@@ -118,7 +119,37 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       "@semantic-release/npm",
-      "@semantic-release/git",
+      [
+        "@google/semantic-release-replace-plugin",
+        {
+          "replacements": [
+            {
+              "files": ["README.md"],
+              "from": "vital-software/monofo#v[-0-9a-z.]*:",
+              "to": "vital-software/monofo#v${nextRelease.version}:",
+              "results": [
+                {
+                  "file": "README.md",
+                  "hasChanged": true,
+                  "numMatches": 1,
+                  "numReplacements": 1
+                }
+              ],
+              "countMatches": true
+            }
+          ]
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "CHANGELOG.md",
+            "package.json",
+            "README.md"
+          ]
+        }
+      ],
       "@semantic-release/github"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch": "run-s \"test --watch\""
   },
   "engines": {
-    "node": ">=12.10"
+    "node": ">=14.16"
   },
   "dependencies": {
     "aws-sdk": "2.1019.0",
@@ -51,7 +51,7 @@
     "@google/semantic-release-replace-plugin": "1.1.0",
     "@semantic-release/changelog": "6.0.1",
     "@semantic-release/git": "10.0.1",
-    "@tsconfig/node12": "1.0.9",
+    "@tsconfig/node14": "1.0.1",
     "@types/bluebird": "3.5.36",
     "@types/debug": "4.1.7",
     "@types/glob": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,20 @@
                 }
               ],
               "countMatches": true
+            },
+            {
+              "files": ["hooks/pre-command"],
+              "from": "MONOFO_VERSION=[-0-9a-z.]*",
+              "to": "MONOFO_VERSION=${nextRelease.version}:",
+              "results": [
+                {
+                  "file": "hooks/pre-command",
+                  "hasChanged": true,
+                  "numMatches": 1,
+                  "numReplacements": 1
+                }
+              ],
+              "countMatches": true
             }
           ]
         }
@@ -146,7 +160,8 @@
           "assets": [
             "CHANGELOG.md",
             "package.json",
-            "README.md"
+            "README.md",
+            "hooks/pre-command"
           ]
         }
       ],

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build:watch": "run-s \"build -w\"",
     "clean": "rm -rf build",
     "commit": "git-cz",
+    "git:sync": "git push plugin +refs/remotes/origin/*:refs/heads/* +refs/tags/*:refs/tags/*",
+    "git:sync:setup": "git remote add plugin git@github.com:vital-software/monofo-buildkite-plugin.git",
     "lint": "eslint \"{src,test}/**/*.ts\"",
     "lint:fix": "run-s \"lint --fix\"",
     "monofo": "./bin/monofo.js",

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,12 @@
+name: Monofo
+description: Dynamically generates monorepo pipelines from multiple subprojects
+author: https://github.com/vital-software
+requirements:
+  - git
+  - aws
+  - npx
+configuration:
+  properties:
+    generate:
+      type: string
+  additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,8 +5,11 @@ requirements:
   - git
   - aws
   - npx
+  - mktemp
 configuration:
   properties:
     generate:
       type: string
+      enum:
+        - pipeline
   additionalProperties: false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*.ts", "bin/*.js"],
-  "extends": "@tsconfig/node12/tsconfig.json"
+  "extends": "@tsconfig/node14/tsconfig.json"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,6 +697,15 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@google/semantic-release-replace-plugin@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@google/semantic-release-replace-plugin/-/semantic-release-replace-plugin-1.1.0.tgz#71316d584efb9feb1267fc7576e50ff6919c02f2"
+  integrity sha512-LaBZmayyxa9eSxJP0dH1FhF3Ye7aXmmkvIGPqR+kA1BxIpEfUqaKk+50puVJ2ERfEPitPmuG2A1utDqMgOgkeg==
+  dependencies:
+    jest-diff "^26.5.2"
+    lodash "^4.17.20"
+    replace-in-file "^6.1.0"
+
 "@humanwhocodes/config-array@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.6.0.tgz#b5621fdb3b32309d2d16575456cbc277fa8f021a"
@@ -889,6 +898,17 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
+
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@jest/types@^27.0.2":
   version "27.0.2"
@@ -1624,6 +1644,13 @@
   version "17.0.7"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.7.tgz#44a484c634761da4391477515a98772b82b5060f"
   integrity sha512-OvLKmpKdea1aWtqHv9bxVVcMoT6syAeK+198dfETIFkAevYRGwqh4H+KFxfjUETZuUuE5sQCAFwdOdoHUdo8eg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.14"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
+  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3182,6 +3209,11 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diff-sequences@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
@@ -4215,7 +4247,7 @@ glob@7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.2.0, glob@^7.1.7:
+glob@7.2.0, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -5238,6 +5270,16 @@ jest-config@^27.3.1:
     micromatch "^4.0.4"
     pretty-format "^27.3.1"
 
+jest-diff@^26.5.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-diff@^27.0.0:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.0.6.tgz#4a7a19ee6f04ad70e0e3388f35829394a44c7b5e"
@@ -5317,6 +5359,11 @@ jest-fetch-mock@3.0.3:
   dependencies:
     cross-fetch "^3.0.4"
     promise-polyfill "^8.1.3"
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-get-type@^27.0.6:
   version "27.0.6"
@@ -6142,7 +6189,7 @@ lodash@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@4.17.21, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7361,6 +7408,16 @@ prettier@2.4.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
+pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^27.0.0, pretty-format@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.6.tgz#ab770c47b2c6f893a21aefc57b75da63ef49a11f"
@@ -7656,6 +7713,15 @@ repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+replace-in-file@^6.1.0:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.3.2.tgz#0f19835137177c89932f45df319f3539a019484f"
+  integrity sha512-Dbt5pXKvFVPL3WAaEB3ZX+95yP0CeAtIPJDwYzHbPP5EAHn+0UoegH/Wg3HKflU9dYBH8UnBC2NvY3P+9EZtTg==
+  dependencies:
+    chalk "^4.1.2"
+    glob "^7.2.0"
+    yargs "^17.2.1"
 
 request@^2.88.2:
   version "2.88.2"
@@ -9148,7 +9214,7 @@ yargs-parser@^20.2.3:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs@17.2.1:
+yargs@17.2.1, yargs@^17.2.1:
   version "17.2.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
   integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1401,10 +1401,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tsconfig/node12@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
-  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+"@tsconfig/node14@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
 
 "@types/babel__core@^7.0.0":
   version "7.1.9"


### PR DESCRIPTION
## Why

Adds the ability to use monofo as a buildkite plugin.

## Approach

### Repo will move

Shortly after merging, we'll rename the repo to `monofo-buildkite-plugin` - this `-buildkite-plugin` suffix is required by Buildkite in order to use the repo as a plugin like:

```yaml
    plugins:
     [...]
      - vital-software/monofo#v3.0.0:
          generate: pipeline
```

Note that the CLI application, environment variables, NPM package, etc. will be unchanged - they'll still all just be `monofo` - renaming the repo just allows us to have a more straightforward usage path.

The only alternatives I could see would be:
 - Sync the repo to another repository URL (annoying to have duplicates, etc.)
 - Specify `ssh://git@github.com/vital-software/monofo.git#v1.0.0` every time we want to use the plugin (but this is annoying, presupposes git usage, is hard to cache etc.)
 
This isn't technically a breaking change, but we'd go to version 3 for this reason alone.

### Drop support for node 12
 
 **Breaking Change**

We'll support the latest node 14+, and drop support for 12 now that it's in [maintenance](https://nodejs.org/en/about/releases/)