### PR TITLE
fix(pure): JSON stringify the commands so that if they're an array we still get them all

### DIFF
--- a/src/steps/record-success.ts
+++ b/src/steps/record-success.ts
@@ -12,7 +12,7 @@ function anonymousKey(step: CommandStep | Step): string {
   hash.update(`${step.label || ''}:`);
   hash.update(JSON.stringify(step.depends_on) || ':');
   hash.update(JSON.stringify(step.plugins) || ':');
-  hash.update(`${(step as CommandStep)?.command || ''}:`);
+  hash.update(`${JSON.stringify(step?.command || step?.commands || '')}:`);
   return `anon-step-${hash.digest('hex').slice(0, 12)}`;
 }
 

--- a/test/cmd/pipeline.test.ts
+++ b/test/cmd/pipeline.test.ts
@@ -208,8 +208,8 @@ describe('monofo pipeline', () => {
         expect(p).toBeDefined();
         expect(p.steps).toHaveLength(4);
         expect(p.steps.map((s) => s.key)).toStrictEqual([
-          'anon-step-cb64da0ef06c',
-          'anon-step-bf2e8e001a41',
+          'anon-step-0f9d3e84a439', // These will change if the hashing algorithm does
+          'anon-step-6da74a8bdeec',
           'record-success-foo',
           'record-success-baz',
         ]);
@@ -305,8 +305,8 @@ describe('monofo pipeline', () => {
       .then((p) => {
         expect(p).toBeDefined();
         expect(p.steps.map((s) => s.key)).toStrictEqual([
-          'anon-step-cb64da0ef06c',
-          'anon-step-bf2e8e001a41',
+          'anon-step-0f9d3e84a439', // These will change if the hashing algorithm does
+          'anon-step-6da74a8bdeec',
           'record-success-foo',
           'record-success-baz',
         ]);


### PR DESCRIPTION
This is dealing with the syntactic sugar that Buildkite adds around command/commands, and making sure we include both in the key of the step hash we're building